### PR TITLE
Remove gnu case range extension in generated yucc code.

### DIFF
--- a/src/yuck-coru.c.m4
+++ b/src/yuck-coru.c.m4
@@ -254,7 +254,16 @@ ifdef([YUCK_SHORTS_HAVE_NUMERALS], [
 				/* [yuck_shorts()] (= yuck_shorts())
 				 * has numerals as shortopts
 				 * don't allow literal treatment of numerals */divert(-1)])
-			case '0' ... '9':;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
 				/* literal treatment of numeral */
 				resume_at(arg);
 


### PR DESCRIPTION
So I tend to run with -Werror -Weverything in clang and -Wall -Wextra -pedantic with gcc when compiling. While its possible to #pragma GCC/clang diagnostic ignored whatever push/etc... away the gnu case range extension with an include wrapper, I think its simpler to just remove the use entirely for generated code. No attempt was made to change any of the use in yuck itself.

This removes warnings such as this for clang compiled generated code:

```
./incipio.yucc:244:13: error: use of GNU case range extension [-Werror,-Wgnu-case-range]
                        case '0' ... '9':;
                                 ^
```

And this for gcc (same test project):

```
incipio.yucc: In function 'yuck_parse':
incipio.yucc:244:4: error: range expressions in switch statements are non-standard [-Werror=pedantic]
    case '0' ... '9':;
    ^
```

All tests seem to pass with the change:

```
PASS: plain_01.clit
PASS: plain_02.clit
PASS: plain_03.clit
PASS: plain_04.clit
PASS: plain_05.clit
PASS: plain_06.clit
PASS: subcmd_01.clit
PASS: subcmd_02.clit
PASS: subcmd_03.clit
PASS: subcmd_04.clit
PASS: option_01.clit
PASS: option_02.clit
PASS: option_03.clit
PASS: option_04.clit
PASS: option_05.clit
PASS: option_06.clit
PASS: option_07.clit
PASS: option_08.clit
PASS: option_09.clit
PASS: option_10.clit
PASS: option_11.clit
PASS: option_12.clit
PASS: optarg_01.clit
PASS: optarg_02.clit
PASS: optarg_03.clit
PASS: optarg_04.clit
PASS: mularg_01.clit
PASS: mularg_02.clit
PASS: mularg_03.clit
PASS: mularg_04.clit
PASS: muloptarg_01.clit
PASS: muloptarg_02.clit
PASS: muloptarg_03.clit
PASS: muloptarg_04.clit
PASS: noauto_01.clit
PASS: noauto_02.clit
PASS: xmpl-01.clit
PASS: xmpl-02.clit
PASS: xmpl-03.clit
PASS: xmpl-04.clit
PASS: xmpl-subcommands-01.clit
PASS: xmpl-subcommands-02.clit
PASS: xmpl-subcommands-03.clit
PASS: xmpl-subcommands-04.clit
PASS: scmver_01.clit
PASS: scmver_02.clit
PASS: generic-muloptarg_01.clit
PASS: generic-muloptarg_02.clit
PASS: generic-muloptarg_03.clit
PASS: generic-muloptarg_04.clit
PASS: generic-mularg_01.clit
PASS: generic-mularg_02.clit
PASS: generic-mularg_03.clit
PASS: generic-mularg_04.clit
PASS: generic-optarg_01.clit
PASS: generic-optarg_02.clit
PASS: generic-optarg_03.clit
PASS: generic-optarg_04.clit
PASS: generic-option_01.clit
PASS: generic-option_02.clit
PASS: generic-option_03.clit
PASS: generic-option_04.clit
PASS: generic-option_05.clit
PASS: generic-option_06.clit
PASS: generic-option_07.clit
PASS: generic-option_08.clit
PASS: post-hook_01.clit
PASS: post-hook_02.clit
PASS: escape_01.clit
PASS: escape_02.clit
PASS: escape_03.clit
PASS: escape_04.clit
PASS: generic-plain_05.clit
PASS: generic-plain_06.clit
PASS: brack_01.clit
PASS: brack_02.clit
PASS: paren_01.clit
PASS: paren_02.clit
PASS: underq_01.clit
PASS: underq_02.clit
PASS: underq_03.clit
PASS: underq_04.clit
PASS: underq_05.clit
PASS: underq_06.clit
PASS: auto-dashdash_01.clit
PASS: auto-dashdash_02.clit
PASS: lone-cmd_01.clit
PASS: lone-cmd_02.clit
PASS: dashdesc_01.clit
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
make[7]: Nothing to be done for `all-am'.
============================================================================
Testsuite summary for yuck 0.1.7.GIT
============================================================================
# TOTAL: 89
# PASS:  89
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
  GEN      version.mk
```
