### PR TITLE
Make git describe use unannotated tags

### DIFF
--- a/src/yuck-scmver.c
+++ b/src/yuck-scmver.c
@@ -593,7 +593,7 @@ git_version(struct yuck_version_s v[static 1U])
 	int rc = 0;
 
 	if ((chld = run(fd, "git", "describe",
-			"--match=v[0-9]*",
+			"--tags", "--match=v[0-9]*",
 			"--abbrev=8", "--dirty", NULL)) < 0) {
 		return -1;
 	}


### PR DESCRIPTION
Use `git describe --tags` so that scmver works with unannotated version tags coming from GitHub releases.