### PR TITLE
Remove dangling dnl in generated man page

### DIFF
--- a/src/yuck.man.m4
+++ b/src/yuck.man.m4
@@ -19,7 +19,7 @@ popdef([alt_desc])dnl
 .SH SYNOPSIS
 .B YUCK_UMB_STR
 [[\fIOPTION\fR]]...[ ]dnl
-ifelse(yuck_cmds(), [], [], [\fICOMMAND\fR])dnl
+ifelse(yuck_cmds(), [], [], [\fICOMMAND\fR])
 []dnl
 yuck_esc(dnl
 yuck_esc(dnl

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -471,6 +471,9 @@ EXTRA_DIST += rudi_14.version
 EXTRA_DIST += rudi_15.version
 EXTRA_DIST += rudi_16.version
 
+TESTS += man-01.clit
+EXTRA_DIST += man-01.yuck
+
 
 ## just to get the tests and yucc files rebuilt
 $(BUILT_SOURCES): $(top_builddir)/src/yuck$(EXEEXT)

--- a/test/man-01.clit
+++ b/test/man-01.clit
@@ -1,0 +1,6 @@
+#!/usr/bin/clitoris
+
+$ ! yuck genman "${srcdir}/man-01.yuck" | grep -- "dnl"
+$
+
+## man-01.clit ends here

--- a/test/man-01.yuck
+++ b/test/man-01.yuck
@@ -1,0 +1,3 @@
+Usage: command
+
+Usage: command subcommand 


### PR DESCRIPTION
I generated a man page and saw `dnl` at the end of the command signature in the *SYNOPSYS* section.

This commit takes out the offending `dnl` from the `m4` script—which didn't seem to break anything—and also introduces a unit test that fails if it finds the term `dnl` in a generated man page.