### PR TITLE
Fix V595 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/yuck.c
+++ b/src/yuck.c
@@ -816,12 +816,16 @@ make_opt_ident(const struct opt_s *arg)
 		bbuf_cpy(i, arg->lopt, strlen(arg->lopt));
 	} else if (arg->sopt) {
 		if (bbuf_cpy(i, "dash.", 5U) != NULL) {
-			i->s[4U] = arg->sopt;
+                        if (i->s) {
+                            i->s[4U] = arg->sopt;
+                        }
 		}
 	} else {
 		static unsigned int cnt;
 		if (bbuf_cpy(i, "idnXXXX", 7U) != NULL) {
-			snprintf(i->s + 3U, 5U, "%u", cnt++);
+                        if (i->s) {
+                            snprintf(i->s + 3U, 5U, "%u", cnt++);
+                        }
 		}
 	}
 	if (LIKELY(i->s != NULL)) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
[V595](https://www.viva64.com/en/w/v595) The 'i->s' pointer was utilized before it was verified against nullptr.